### PR TITLE
Fix navigation on "many usages" click

### DIFF
--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/PageUrlCell/PageUrlCell.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/PageUrlCell/PageUrlCell.tsx
@@ -1,25 +1,31 @@
 import { Disclose } from "optimizely-oui";
-import React from "react";
+import React, { useCallback } from "react";
 import PageUrlLink from "./PageUrlLink/PageUrlLink";
 import { HoverHandlers } from "../../../Lib/hooks/useHoverTrackingHandlers";
 
 interface PageUrlCellProps {
-    pageUrls: string[];
-    urlHoveredHandlers: HoverHandlers;
+  pageUrls: string[];
+  urlHoveredHandlers: HoverHandlers;
 }
 
-const PageUrlCell = ({pageUrls, urlHoveredHandlers}: PageUrlCellProps) => {
-    const isManyUrls = pageUrls.length > 1;
-  
-    return isManyUrls ? (
+const PageUrlCell = ({pageUrls,urlHoveredHandlers}: PageUrlCellProps) => {
+  const isManyUrls = pageUrls.length > 1;
+
+  const discloseHeaderClickHandler = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  return isManyUrls ? (
+    <div onClick={discloseHeaderClickHandler}>
       <Disclose title="Many usages">
         {pageUrls.map((pageUrl, index) => (
           <PageUrlLink key={index} pageUrl={pageUrl} urlHoveredHandlers={urlHoveredHandlers}/>
         ))}
       </Disclose>
-    ) : (
-      <PageUrlLink pageUrl={pageUrls[0]} urlHoveredHandlers={urlHoveredHandlers}/>
-    );
-  }
+    </div>
+  ) : (
+    <PageUrlLink pageUrl={pageUrls[0]} urlHoveredHandlers={urlHoveredHandlers}/>
+  );
+}
 
-  export default PageUrlCell;
+export default PageUrlCell;


### PR DESCRIPTION
I saw a problem that when "many usages" was clicked it navigated to edit page.

Now header click stops event propagation.