### PR TITLE
Refactoring/77 split content type usages table

### DIFF
--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Router.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Router.tsx
@@ -22,7 +22,6 @@ interface RouterProps {
 interface LoadDataFunction {
   (
     apiClient: ContentUsageAPIClient,
-    initialLoad: boolean,
     args: LoaderFunctionArgs
   ): Promise<any> | Response;
 }
@@ -36,7 +35,6 @@ const contentTypesLoader: LoadDataFunction = (api) => {
 
 const contentTypeUsagesLoader: LoadDataFunction = (
   api,
-  initialLoad,
   { request, params }
 ) => {
   if (!params.guid) return redirect(routes.index);
@@ -48,18 +46,13 @@ const contentTypeUsagesLoader: LoadDataFunction = (
     ...query,
   });
 
-  if (initialLoad) {
-    const contentType = api.getContentType(params.guid);
+  const contentType = api.getContentType(params.guid);
 
-    return Promise.all([contentType, contentTypeUsages]);
-  }
-
-  return contentTypeUsages;
+  return Promise.all([contentType, contentTypeUsages]);
 };
 
 const Router = ({ baseUrl }: RouterProps) => {
   setBaseUrl(baseUrl);
-  const initialLoadRef = useRef<boolean>(true);
   const api = useAPI();
 
   const loadData = useCallback(
@@ -67,10 +60,8 @@ const Router = ({ baseUrl }: RouterProps) => {
       async (args: LoaderFunctionArgs) => {
         const data = await loaderFunction(
           apiClient,
-          initialLoadRef.current,
           args
         );
-        initialLoadRef.current = false;
         return data;
       },
     []

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeTable/ContentTypeTableRow.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeTable/ContentTypeTableRow.tsx
@@ -1,0 +1,84 @@
+import { Table, Dropdown, ButtonIcon } from "optimizely-oui";
+import React, { FC, useCallback } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import { ContentTypeDto } from "../../../dtos";
+import { TableColumn } from "../../../types";
+import { useTranslations } from "../../../Contexts/TranslationsProvider";
+import { useNavigate } from "react-router-dom";
+import { viewContentTypeUsages } from "../../../routes";
+import TableRow from "../TableRow";
+
+interface ContentTypeTableRowProps {
+  row: ContentTypeDto;
+  tableColumns: TableColumn<ContentTypeDto>[];
+}
+
+const ContentTypeTableRow: FC<ContentTypeTableRowProps> = ({
+  row,
+  tableColumns,
+}) => {
+  const translations = useTranslations();
+  const {
+    views: {
+      contentTypesView: {
+        table: { actions },
+      },
+    },
+  } = translations;
+
+  const navigate = useNavigate();
+
+  const onTableRowClick = useCallback(
+    (guid: string, alwaysTriggerClick = false) =>
+      (event: React.PointerEvent) => {
+        const target = event.target as HTMLTableCellElement | undefined;
+
+        if ((target && target.tagName === "TD") || alwaysTriggerClick) {
+          navigate(viewContentTypeUsages(guid));
+        }
+      },
+    [navigate]
+  );
+
+  return (
+    <TableRow
+      key={row.guid}
+      row={row}
+      tableColumns={tableColumns}
+      onTableRowClick={onTableRowClick(row.guid)}
+      additionalCellAtTheRowEnd={
+        <Table.TD verticalAlign="middle">
+          <Dropdown
+            activator={
+              <ButtonIcon
+                iconName="ellipsis"
+                size="small"
+                style="plain"
+                title={actions.title}
+              />
+            }
+          >
+            <Dropdown.Contents>
+              <Dropdown.ListItem
+                onClick={onTableRowClick(row.guid, true)}
+              >
+                <Dropdown.BlockLink>
+                  <Dropdown.BlockLinkText text={actions.viewUsages} />
+                </Dropdown.BlockLink>
+              </Dropdown.ListItem>
+              <Dropdown.ListItem>
+                <CopyToClipboard text={row.guid}>
+                  <Dropdown.BlockLink>
+                    <Dropdown.BlockLinkText text={actions.copyGuid} />
+                  </Dropdown.BlockLink>
+                </CopyToClipboard>
+              </Dropdown.ListItem>
+            </Dropdown.Contents>
+          </Dropdown>
+        </Table.TD>
+      }
+    />
+  );
+};
+
+export default ContentTypeTableRow;

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTable.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTable.tsx
@@ -10,7 +10,7 @@ enum ContentTypeUsageTableColumn {
   ID = "id",
   Name = "name",
   LanguageBranch = "languageBranch",
-  PageUrl = "pageUrl",
+  PageUrls = "pageUrls",
   Actions = "actions",
 }
 

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTable.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTable.tsx
@@ -28,13 +28,13 @@ const ContentTypeUsagesTable = ({
   sortDirection,
 }: ContentTypeUsagesTableProps) => {
   const onTableRowClick = useCallback(
-    (url?: string | null, alwaysTriggerClick = false) =>
+    (url?: string | null) =>
       (event: React.PointerEvent) => {
         if (!url) return;
 
         const target = event.target as HTMLTableCellElement | undefined;
 
-        if ((target && target.tagName === "TD") || alwaysTriggerClick) {
+        if (target) {
           navigateTo(url, true);
         }
       },

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTableRow/ContentTypeUsageTableRow.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTableRow/ContentTypeUsageTableRow.tsx
@@ -3,49 +3,64 @@ import { useTranslations } from "../../../../Contexts/TranslationsProvider";
 import { ContentUsageDto } from "../../../../dtos";
 import { TableColumn } from "../../../../types";
 import PageUrlCell from "../../PageUrlCell/PageUrlCell";
-import React from "react";
-import { ContentTypeUsageTableColumn } from "../ContentTypeUsageTable";
+import React, { useCallback } from "react";
 import { useHoverTrackingHandlers } from "../../../../Lib/hooks/useHoverTrackingHandlers";
+import { navigateTo } from "../../../../routes";
+import TableRow from "../../TableRow";
 
 interface ContentTypeUsageTableRowProps<TableDataType> extends ContentUsageDto {
-    tableColumns: TableColumn<TableDataType>[];
-    onRowClick?: (event: React.PointerEvent) => void;
+  tableColumns: TableColumn<TableDataType>[];
+  onRowClick?: (event: React.PointerEvent) => void;
 }
 
 const ContentTypeUsageTableRow = ({
-    tableColumns,
-    onRowClick,
-    ...row
-  }: ContentTypeUsageTableRowProps<ContentUsageDto>) => {
-    const {
-      views: {
-        contentUsagesView: {
-          table: { actions },
-        },
+  tableColumns,
+  onRowClick,
+  ...row
+}: ContentTypeUsageTableRowProps<ContentUsageDto>) => {
+  const {
+    views: {
+      contentUsagesView: {
+        table: { actions },
       },
-    } = useTranslations();
+    },
+  } = useTranslations();
 
-    const [isUrlHovered, urlHoveredHandlers] = useHoverTrackingHandlers();
-    const actionLabel = isUrlHovered ? actions.view : actions.edit;
+  const [isUrlHovered, urlHoveredHandlers] = useHoverTrackingHandlers();
+  const actionLabel = isUrlHovered ? actions.view : actions.edit;
 
-    return (
-      <Table.TR className="forte-optimizely-content-usage-table-row" onRowClick={onRowClick}>
-        { tableColumns
-          .filter((column) => column.visible)
-          .map((column) =>
-          <Table.TD key={column.id} colSpan={column.columnSpanWidth}>
-            { column.id.toString() === ContentTypeUsageTableColumn.PageUrl &&
-            row.pageUrls.length > 0 ? (
-                <PageUrlCell pageUrls={row.pageUrls} urlHoveredHandlers={urlHoveredHandlers}/>
-            ) : (
-                row[column.id]
-            )}
-          </Table.TD>
-        )}
-        <Table.TD colSpan={1}><span className="forte-optimizely-content-usage-action-label">{actionLabel + " >"}</span></Table.TD>
-      </Table.TR>
-    );
-  };
+  const onTableRowClick = useCallback(
+    (url?: string | null) => (event: React.PointerEvent) => {
+      if (!url) return;
+
+      const target = event.target as HTMLTableCellElement | undefined;
+
+      if (target && target.tagName === "TD") {
+        navigateTo(url, true);
+      }
+    },
+    [navigateTo]
+  );
+
+  return (
+    <TableRow
+      key={`${row.id}-${row.languageBranch}`}
+      className="forte-optimizely-content-usage-table-row"
+      row={row}
+      tableColumns={tableColumns}
+      onTableRowClick={onTableRowClick(row.editUrl)}
+      specificCells={{
+        pageUrls: (_, pageUrls) => <PageUrlCell pageUrls={pageUrls} urlHoveredHandlers={urlHoveredHandlers}/>
+      }}
+      additionalCellAtTheRowEnd={
+        <Table.TD colSpan={1}>
+          <span className="forte-optimizely-content-usage-action-label">
+            {actionLabel + " >"}
+          </span>
+        </Table.TD>
+      }
+    />
+  );
+};
 
 export default ContentTypeUsageTableRow;
-  

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ForteTable.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/ForteTable.tsx
@@ -1,0 +1,45 @@
+import { Table, Dropdown, ButtonIcon } from "optimizely-oui";
+import React, { FC, ReactNode, useCallback } from "react";
+import { translations } from "../../translations";
+import { SortDirection, TableColumn } from "../../types";
+import { SortChangeHandler } from "../../Lib/hooks/useFilteredTableData";
+import TableHeader from "./TableHeader";
+
+interface ForteTableProps<TItem> {
+    tableColumns: TableColumn<TItem>[];
+    rows: TItem[];
+    rowTemplate: (row: TItem, columns: TableColumn<TItem>[]) => ReactNode;
+    sortDirection: SortDirection;
+    onSortChange: SortChangeHandler<TItem>
+}
+ 
+function ForteTable<TItem>({
+  rows,
+  rowTemplate,
+  tableColumns,
+  sortDirection,
+  onSortChange,
+}: ForteTableProps<TItem>) {
+  return (
+    <Table
+      className="forte-optimizely-content-usage-table"
+      shouldAddHover={rows.length > 0}
+    >
+      <TableHeader tableColumns={tableColumns} sortDirection={sortDirection} onSortChange={onSortChange} />
+
+      <Table.TBody>
+        {rows.length > 0 ? (
+          rows.map((row) => (
+            rowTemplate(row, tableColumns)
+          ))
+        ) : (
+          <Table.TR noHover>
+            <Table.TD colSpan={6}>{translations.noResults}</Table.TD>
+          </Table.TR>
+        )}
+      </Table.TBody>
+    </Table>
+  );
+};
+ 
+export default ForteTable;

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableHeader.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableHeader.tsx
@@ -1,0 +1,39 @@
+import { Table } from "optimizely-oui";
+import React, { FC } from "react";
+import { SortDirection, TableColumn } from "../../types";
+
+interface TableHeaderProps<TItem> {
+  tableColumns: TableColumn<TItem>[];
+  sortDirection: SortDirection;
+  onSortChange: (column: TableColumn<TItem>) => void;
+}
+
+function TableHeader<TItem>({
+  tableColumns,
+  sortDirection,
+  onSortChange,
+}: TableHeaderProps<TItem>) {
+  return (
+    <Table.THead>
+      <Table.TR>
+        {tableColumns
+          .filter((column) => column.visible)
+          .map((column) => (
+            <Table.TH
+              sorting={{
+                canSort: true,
+                handleSort: () => onSortChange(column),
+                order: sortDirection,
+              }}
+              key={column.id}
+            >
+              {column.name}
+            </Table.TH>
+          ))}
+        <Table.TH width={100} />
+      </Table.TR>
+    </Table.THead>
+  );
+};
+
+export default TableHeader;

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableRow.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableRow.tsx
@@ -20,7 +20,7 @@ function TableRow<TItem>({
   tableColumns,
   onTableRowClick,
   additionalCellAtTheRowEnd,
-  specificCells,
+  specificCells = {},
 }: TableRowProps<TItem>) {
   const renderCell = useCallback(
     (column: TableColumn<TItem>, row: TItem) => {

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableRow.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Components/Tables/TableRow.tsx
@@ -1,0 +1,52 @@
+import { Table } from "optimizely-oui";
+import React, { ReactNode, useCallback } from "react";
+import { TableColumn } from "../../types";
+
+
+interface TableRowProps<TItem> {
+    key: unknown;
+    className?: string;
+    row: TItem;
+    tableColumns: TableColumn<TItem>[];
+    onTableRowClick: (event: React.PointerEvent) => void;
+    additionalCellAtTheRowEnd?: ReactNode;
+    specificCells?: {[c in keyof TItem]?: (column: TableColumn<TItem>, row: TItem[c]) => ReactNode};
+}
+ 
+function TableRow<TItem>({
+  key,
+  className,
+  row,
+  tableColumns,
+  onTableRowClick,
+  additionalCellAtTheRowEnd,
+  specificCells,
+}: TableRowProps<TItem>) {
+  const renderCell = useCallback(
+    (column: TableColumn<TItem>, row: TItem) => {
+      const specificCell = specificCells[column.id];
+
+      if (specificCell !== undefined) {
+        return specificCell(column, row[column.id]);
+      }
+
+      return row[column.id];
+    },
+    [specificCells]
+  );
+
+  return (
+    <Table.TR key={key} className={className} onRowClick={onTableRowClick}>
+      {tableColumns
+        .filter((column) => column.visible)
+        .map((column) => (
+          <Table.TD key={column.id} colSpan={column.columnSpanWidth}>
+            {renderCell(column, row)}
+          </Table.TD>
+        ))}
+      {additionalCellAtTheRowEnd}
+    </Table.TR>
+  );
+}
+ 
+export default TableRow;

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Lib/hooks/useFilteredTableData.ts
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Lib/hooks/useFilteredTableData.ts
@@ -32,6 +32,8 @@ interface FilteredTableDataHookOptions<TableDataType> {
   defaultVisiableColumn: keyof TableDataType;
 }
 
+export type SortChangeHandler<TableDataType> = (column: TableColumn<TableDataType>) => void;
+
 export function useFilteredTableData<TableDataType>({
   rows,
   initialContentTypeBases,

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypeUsageView.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypeUsageView.tsx
@@ -8,17 +8,11 @@ import React, {
 import { Breadcrumb } from "@episerver/ui-framework";
 import { TableColumn } from "../types";
 import {
-  ButtonIcon,
-  Disclose,
-  DiscloseTable,
-  Dropdown,
   Grid,
   GridCell,
   GridContainer,
-  Link,
   PaginationControls,
   Spinner,
-  Table,
 } from "optimizely-oui";
 import { useLoaderData, useLocation } from "react-router-dom";
 import Layout from "../Components/Layout";
@@ -94,7 +88,7 @@ const ContentTypeUsageView = () => {
       columnSpanWidth: 2,
     },
     {
-      id: ContentTypeUsageTableColumn.PageUrl,
+      id: ContentTypeUsageTableColumn.PageUrls,
       name: columns.pageUrl,
       visible: true,
       sorting: false,

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypeUsageView.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypeUsageView.tsx
@@ -32,9 +32,7 @@ import { useScroll } from "../Lib/hooks/useScroll";
 import "./ContentTypeUsageView.scss";
 import ContentTypeUsagesTable, { ContentTypeUsageTableColumn } from "../Components/Tables/ContentTypeUsagesTable/ContentTypeUsageTable";
 
-type ContentTypeUsageViewResponse =
-  | APIResponse<GetContentUsagesResponse>
-  | ContentTypeUsageViewInitialResponse;
+type ContentTypeUsageViewResponse = ContentTypeUsageViewInitialResponse;
 
 type ContentTypeUsageViewInitialResponse = [
   APIResponse<ContentTypeDto>,
@@ -168,15 +166,7 @@ const ContentTypeUsageView = () => {
 
   useEffect(() => {
     if (response) {
-      if (Array.isArray(response)) {
-        setDataFromInitialResponse(response);
-      } else if (response.data && !response.hasErrors) {
-        setContentTypeUsages(response.data.contentUsages);
-        setTotalPages(response.data.totalPages);
-
-        if (!contentTypeDisplayName)
-          setContentTypeDisplayName(location.state?.contentType?.displayName);
-      }
+      setDataFromInitialResponse(response);
       setDataLoaded(true);
     }
   }, [response]);

--- a/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypesView.tsx
+++ b/src/Forte.Optimizely.ContentUsage/Frontend/Views/ContentTypesView.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ButtonIcon,
   Dropdown,
@@ -25,6 +20,8 @@ import { useTranslations } from "../Contexts/TranslationsProvider";
 import { useFilteredTableData } from "../Lib/hooks/useFilteredTableData";
 import { TableColumn } from "../types";
 import { useScroll } from "../Lib/hooks/useScroll";
+import ForteTable from "../Components/Tables/ForteTable";
+import ContentTypeTableRow from "../Components/Tables/ContentTypeTable/ContentTypeTableRow";
 
 enum ContentTypesTableColumn {
   GUID = "guid",
@@ -87,20 +84,6 @@ const ContentTypesView = () => {
     },
   ] as TableColumn<ContentTypeDto>[];
 
-  const onTableRowClick = useCallback(
-    (guid: string, displayName: string, alwaysTriggerClick = false) =>
-      (event: React.PointerEvent) => {
-        const target = event.target as HTMLTableCellElement | undefined;
-
-        if ((target && target.tagName === "TD") || alwaysTriggerClick) {
-          navigate(viewContentTypeUsages(guid), {
-            state: { contentType: { displayName: displayName } },
-          });
-        }
-      },
-    [navigate]
-  );
-
   const {
     rows,
     searchValue,
@@ -121,7 +104,7 @@ const ContentTypesView = () => {
     rows: contentTypes,
     initialTableColumns,
     initialContentTypeBases,
-    defaultVisiableColumn: "displayName"
+    defaultVisiableColumn: "displayName",
   });
 
   const handlePageChange = useCallback(
@@ -185,93 +168,15 @@ const ContentTypesView = () => {
 
           <GridCell large={12} medium={8} small={4}>
             <div className="forte-optimizely-content-usage-table-container">
-              <Table
-                className="forte-optimizely-content-usage-table"
-                shouldAddHover={rows.length > 0}
-              >
-                <Table.THead>
-                  <Table.TR>
-                    {tableColumns
-                      .filter((column) => column.visible)
-                      .map((column) => (
-                        <Table.TH
-                          sorting={{
-                            canSort: true,
-                            handleSort: () => onSortChange(column),
-                            order: sortDirection,
-                          }}
-                          key={column.id}
-                        >
-                          {column.name}
-                        </Table.TH>
-                      ))}
-                    <Table.TH width={100} />
-                  </Table.TR>
-                </Table.THead>
-
-                <Table.TBody>
-                  {rows.length > 0 ? (
-                    rows.map((row) => (
-                      <Table.TR
-                        key={row.guid}
-                        onRowClick={onTableRowClick(
-                          row.guid,
-                          row.displayName || row.name
-                        )}
-                      >
-                        {tableColumns
-                          .filter((column) => column.visible)
-                          .map((column) => (
-                            <Table.TD key={column.id}>
-                              {row[column.id]}
-                            </Table.TD>
-                          ))}
-                        <Table.TD verticalAlign="middle">
-                          <Dropdown
-                            activator={
-                              <ButtonIcon
-                                iconName="ellipsis"
-                                size="small"
-                                style="plain"
-                                title={actions.title}
-                              />
-                            }
-                          >
-                            <Dropdown.Contents>
-                              <Dropdown.ListItem
-                                onClick={onTableRowClick(
-                                  row.guid,
-                                  row.displayName || row.name,
-                                  true
-                                )}
-                              >
-                                <Dropdown.BlockLink>
-                                  <Dropdown.BlockLinkText
-                                    text={actions.viewUsages}
-                                  />
-                                </Dropdown.BlockLink>
-                              </Dropdown.ListItem>
-                              <Dropdown.ListItem>
-                                <CopyToClipboard text={row.guid}>
-                                  <Dropdown.BlockLink>
-                                    <Dropdown.BlockLinkText
-                                      text={actions.copyGuid}
-                                    />
-                                  </Dropdown.BlockLink>
-                                </CopyToClipboard>
-                              </Dropdown.ListItem>
-                            </Dropdown.Contents>
-                          </Dropdown>
-                        </Table.TD>
-                      </Table.TR>
-                    ))
-                  ) : (
-                    <Table.TR noHover>
-                      <Table.TD colSpan={6}>{translations.noResults}</Table.TD>
-                    </Table.TR>
-                  )}
-                </Table.TBody>
-              </Table>
+              <ForteTable
+                tableColumns={tableColumns}
+                rows={rows}
+                rowTemplate={(row, columns) => (
+                  <ContentTypeTableRow row={row} tableColumns={columns} />
+                )}
+                sortDirection={sortDirection}
+                onSortChange={onSortChange}
+              />
             </div>
           </GridCell>
 


### PR DESCRIPTION
Review after merging #80 

This PR splits Content Type Usages view table components.

It also fixes a problem with breakcrumbs. I decided to remove saving history state and data for breadcrumbs are gotten from API.